### PR TITLE
fix(orders) - createdBy value on create

### DIFF
--- a/apps/api/src/order/dto/create-order.dto.ts
+++ b/apps/api/src/order/dto/create-order.dto.ts
@@ -1,5 +1,10 @@
 import { OmitType } from '@nestjs/mapped-types';
-import { OrderSideEnum, OrderStatusEnum, OrderTypeEnum } from '@prisma/client';
+import {
+  OrderCreatedByEnum,
+  OrderSideEnum,
+  OrderStatusEnum,
+  OrderTypeEnum,
+} from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import {
   IsDateString,
@@ -100,4 +105,8 @@ export class CreateOrderDbDto extends OmitType(CreateOrderDto, ['timestamp']) {
 
   @IsOptional()
   rawData: string;
+
+  @IsEnum(OrderCreatedByEnum)
+  @IsOptional()
+  createdBy: OrderCreatedByEnum = OrderCreatedByEnum.USER;
 }

--- a/apps/api/src/order/dto/order-dto.mapper.ts
+++ b/apps/api/src/order/dto/order-dto.mapper.ts
@@ -10,6 +10,7 @@ import {
   OrderStatusEnum,
   OrderTypeEnum,
   OrderSideEnum,
+  OrderCreatedByEnum,
 } from '@prisma/client';
 
 /**
@@ -118,6 +119,7 @@ export const ccxtToCreateOrderDbDto = (
     fee: ccxtOrder.fee.cost,
     accessKeyId: accessKeyId,
     userId,
+    createdBy: OrderCreatedByEnum.SCRIPT,
     rawData: ccxtOrder,
   };
 };

--- a/apps/api/src/order/stubs/index.ts
+++ b/apps/api/src/order/stubs/index.ts
@@ -72,3 +72,73 @@ export const updateOrderStubStatic = OrderStub(
 );
 
 export const orderStubs = [orderStubStatic, orderStubStatic2];
+
+export const ccxtOrderStatic = {
+  id: 'OP3C2A-PFHLH-Q5IAGH',
+  fee: {
+    cost: '0.16000',
+    currency: 'EUR',
+  },
+  cost: 99.999450372,
+  fees: [
+    {
+      cost: 0.16,
+      currency: 'EUR',
+    },
+  ],
+  info: {
+    id: 'OP3C2A-PFHLH-Q5IAGH',
+    fee: '0.16000',
+    vol: '0.00210468',
+    cost: '99.99966',
+    misc: '',
+    descr: {
+      pair: 'XBTEUR',
+      type: 'buy',
+      close: '',
+      order: 'buy 0.00210468 XBTEUR @ limit 47513.0',
+      price: '47513.0',
+      aclass: 'forex',
+      price2: '0',
+      leverage: 'none',
+      ordertype: 'limit',
+    },
+    price: '47512.9',
+    refid: null,
+    oflags: 'fciq',
+    opentm: '1708370795.703035',
+    reason: null,
+    status: 'closed',
+    trades: ['TOZUQI-7Z4VG-7Y2WYL'],
+    closetm: '1708443071.950905',
+    starttm: '0',
+    userref: '0',
+    expiretm: '0',
+    vol_exec: '0.00210468',
+    stopprice: '0.00000',
+    limitprice: '0.00000',
+  },
+  side: 'buy',
+  type: 'limit',
+  price: 47513,
+  amount: 0.00210468,
+  filled: 0.00210468,
+  status: 'closed',
+  symbol: 'BTC/EUR',
+  trades: [
+    {
+      id: 'TOZUQI-7Z4VG-7Y2WYL',
+      fee: {},
+      fees: [],
+      info: {},
+      symbol: 'BTC/EUR',
+      orderId: 'OP3C2A-PFHLH-Q5IAGH',
+    },
+  ],
+  average: 47512.9,
+  datetime: '2024-02-19T19:26:35.703Z',
+  postOnly: false,
+  remaining: 0,
+  timestamp: 1708370795703,
+  clientOrderId: '0',
+};


### PR DESCRIPTION
- Set order.createdBy to USER, when a user manually creates an order
- Set order.createdBy to SCRIPT, when the user syncs their order from an exchange