### PR TITLE
feat(GlobalExceptionFilter) - Catch all exceptions

### DIFF
--- a/apps/api/src/shared/filters/global-exception.filter.ts
+++ b/apps/api/src/shared/filters/global-exception.filter.ts
@@ -1,0 +1,39 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
+
+/**
+ * Global exception filter that catches all unhandled exceptions across the application.
+ *
+ * This filter provides a centralized way to handle exceptions and transform them into
+ * consistent HTTP responses. It can optionally use an ExceptionTransformer function
+ * to convert specific exceptions (like Prisma errors) into standardized HttpException
+ * objects before sending the response to the client.
+ *
+ * The filter ensures all exceptions are properly formatted with appropriate HTTP status
+ * codes and response structures, maintaining consistency across the API.
+ */
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  constructor(
+    private readonly ExceptionTransformer?: (exception: any) => HttpException,
+  ) {}
+  catch(exception: any, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+
+    // Transform exception if transformer is provided, otherwise use as-is
+    const transformedException = this.ExceptionTransformer
+      ? this.ExceptionTransformer(exception)
+      : exception;
+
+    const status = transformedException.getStatus();
+
+    response.status(status).json({
+      ...transformedException.getResponse(),
+    });
+  }
+}


### PR DESCRIPTION
Set up a global exception handler that uses the GlobalException filter to catch all exceptions and apply an optional transformer function. This allows for the transformation of database-specific exceptions, like P2002 unique constraint errors, into standard Http responses that match the validation pipe's error format