### PR TITLE
fix(signup) — Unique email constraint

### DIFF
--- a/apps/api/src/app/app.config.ts
+++ b/apps/api/src/app/app.config.ts
@@ -14,6 +14,7 @@ import * as hbs from 'hbs';
 import { ValidationError } from 'class-validator';
 import type { Request } from 'express';
 import { GlobalExceptionFilter } from '@/shared/filters/global-exception.filter';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 
 /**
  * Set up Morgan HTTP request logging
@@ -93,7 +94,10 @@ export function setupPipes(app: NestExpressApplication | INestApplication) {
   app.useGlobalFilters(
     new GlobalExceptionFilter((exception: any) => {
       // Check if it's a Prisma unique constraint violation
-      if (exception.code === 'P2002') {
+      if (
+        exception instanceof PrismaClientKnownRequestError &&
+        exception.code === 'P2002'
+      ) {
         const field = exception.meta?.target?.[0] || 'unknown';
         return new BadRequestException([
           {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -2,7 +2,6 @@ import * as argon from 'argon2';
 import { ForbiddenException, Injectable } from '@nestjs/common';
 import { AuthDto } from './dto';
 import { PrismaService } from '../prisma/prisma.service';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { JwtService, JwtSignOptions } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UserService } from 'src/user/user.service';
@@ -117,25 +116,15 @@ export class AuthService {
    * @returns
    */
   async jwtSignup(dto: AuthDto) {
-    try {
-      const hash = await argon.hash(dto.password);
+    const hash = await argon.hash(dto.password);
 
-      const createUserDto: CreateUserDto = {
-        email: dto.email,
-        hash,
-      };
-      const user = await this.userService.createUser(createUserDto);
+    const createUserDto: CreateUserDto = {
+      email: dto.email,
+      hash,
+    };
+    const user = await this.userService.createUser(createUserDto);
 
-      return this.signJwtToken(user.id, user.email, user.role);
-    } catch (error) {
-      if (error instanceof PrismaClientKnownRequestError) {
-        // Unique constraint violation - The provided email is reserved by another user
-        if (error.code === 'P2002') {
-          throw new ForbiddenException('Credentials taken');
-        }
-      }
-      throw error;
-    }
+    return this.signJwtToken(user.id, user.email, user.role);
   }
 
   /**


### PR DESCRIPTION
Rely on the GlobalExceptionHandler to return a validation error in case a new user tries to sign up with an already reserved email